### PR TITLE
Chatlog URL fix

### DIFF
--- a/src/de/tutorialwork/main/Main.java
+++ b/src/de/tutorialwork/main/Main.java
@@ -207,7 +207,7 @@ public class Main extends Plugin {
                 }
                 if(!configcfg.getString("WEBINTERFACE.URL").equals("https://DeinServer.de/Webinterface")){
                     WebURL = configcfg.getString("WEBINTERFACE.URL");
-                    if(!WebURL.startsWith("https://") || !WebURL.startsWith("http://")){
+                    if(!WebURL.startsWith("https://") && !WebURL.startsWith("http://")){
                         WebURL = "https://" + WebURL;
                     }
                     if(!WebURL.endsWith("/")){


### PR DESCRIPTION
Wenn man in der Config die Chatlog-URL mit http:// eingibt, wird bei dieser am Anfang https:// angezeigt. Dieser Fehler wird damit behoben.